### PR TITLE
Resolve the issue with the UI-Builder page not found.

### DIFF
--- a/code-studio-toc.html
+++ b/code-studio-toc.html
@@ -174,7 +174,7 @@
                 <a href="/code-studio/reference/configure-properties/Tools">Tools</a>
                 <ul>
                     <li>
-                        <a href="/code-studio/reference/configure-properties/ui-builder/UI-Builder.md">UI Builder</a>
+                        <a href="/code-studio/reference/configure-properties/ui-builder/UI-Builder">UI Builder</a>
                     </li>
                 </ul>
             </li>


### PR DESCRIPTION
### Description

Resolved the issue of the UI-Builder UG page not being found. This issue occurred due to the existing URL of the file path that came with .md.

### Solution

Provide the proper URL without using .md at the end of the file path URL.